### PR TITLE
Use dynver to keep track of the version

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "2.1.0")
+
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"         % "1.1.0-M1")
 addSbtPlugin("com.github.gseitz" % "sbt-release"     % "1.0.6")
 addSbtPlugin("org.scalariform"  % "sbt-scalariform" % "1.8.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "0.2.0"


### PR DESCRIPTION
During release 0.3.0 it seems version.sbt was not updated,
this hopefully avoids that in the future. Not entirely sure how that interacts
with sbt-release, are we still using that for sbt-java-formatter?