### PR TITLE
updates version to next SNAPSHOT

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.0"
+version in ThisBuild := "0.3.1-SNAPSHOT"


### PR DESCRIPTION
Latest version released was `0.3.0` but `version.sbt` still points to `0.2.0`. I don't really know if `version.sbt` is still in use. 

It should either be updated (this PR) or removed (close this PR and remove the file)