### PR TITLE
Cross publish for sbt 0.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ jobs:
        script: sbt scripted
 
      - stage: publish
-       script: sbt publish
+       script:
+        - sbt publish
+        - sbt ^^0.13.18 ++2.10.7 publish
 
 stages:
   # runs on master commits and PRs


### PR DESCRIPTION
I'm in the process of introducing Scalafmt and sbt-java-formatter to Play.  I hadn't realised that this plugin was no longer available for sbt 0.13.  I plan to upgrade Play's build, but I've already started the disruptive process of reformatting (and other big changes) in the Play repo, so I'd like to finish that first, and then upgrade to sbt 1.  Seeing as this still compiles fine with sbt 0.13, could we add this, please?  I can make sure to remove it again soon after.