### PR TITLE
Don't trigger AutomateJavaFormatterPlugin by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % --latest version---)
 
 For available versions see [releases](https://github.com/sbt/sbt-java-formatter/releases).
 
-* `javafmt` formats Java files (done automatically on `compile` for `Compile` and `Test` configurations, unless `AutomateJavaFormatterPlugin` is disabled)
+* `javafmt` formats Java files (can be done automatically on `compile` for `Compile` and `Test` configurations, by enabling the `AutomateJavaFormatterPlugin`)
 * `javafmtAll` formats Java files for all configurations (`Compile` and `Test` by default)
 * `javafmtCheck` fails if files need reformatting
 * `javafmtCheckAll` fails if files need reformatting in any configuration (`Compile` and `Test` by default)

--- a/plugin/src/main/scala/com/lightbend/sbt/JavaFormatterPlugin.scala
+++ b/plugin/src/main/scala/com/lightbend/sbt/JavaFormatterPlugin.scala
@@ -21,8 +21,6 @@ import sbt.Keys._
 import sbt.{ Def, _ }
 
 object AutomateJavaFormatterPlugin extends AutoPlugin {
-  override def trigger = allRequirements
-
   override def `requires` = plugins.JvmPlugin
 
   override def projectSettings =

--- a/plugin/src/sbt-test/sbt-java-formatter/default/build.sbt
+++ b/plugin/src/sbt-test/sbt-java-formatter/default/build.sbt
@@ -1,1 +1,1 @@
-// no settings needed
+lazy val root = (project in file(".")).enablePlugins(AutomateJavaFormatterPlugin)

--- a/plugin/src/sbt-test/sbt-java-formatter/multi-module-crawl-up-for-file/test
+++ b/plugin/src/sbt-test/sbt-java-formatter/multi-module-crawl-up-for-file/test
@@ -1,4 +1,3 @@
-# compile should trigger formatting
 -> javafmtCheck
 > javafmt
 -> javafmtCheckAll


### PR DESCRIPTION
I don't think formatting on compile is a good idea:
`sbt-scalafmt` has "format on compile" disabled for very good reasons: 
> This option is **discouraged** since it messes up undo buffers in the editor and it slows down compilation. It is recommended to use "format on save" in the editor instead.

Source: https://scalameta.org/scalafmt/docs/installation.html#format-on-compile
IMHO the same applies for java source files.

I think it's much better to disable formatting on compile by default.

Thanks!