### PR TITLE
Add javafmtOnCompile setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % --latest version---)
 
 For available versions see [releases](https://github.com/sbt/sbt-java-formatter/releases).
 
-* `javafmt` formats Java files (done automatically on `compile` for `Compile` and `Test` configurations, unless `AutomateJavaFormatterPlugin` is disabled)
+* `javafmt` formats Java files (done automatically on `compile` for `Compile` and `Test` configurations, unless `javafmtOnCompile := false` is set)
 * `javafmtAll` formats Java files for all configurations (`Compile` and `Test` by default)
 * `javafmtCheck` fails if files need reformatting
 * `javafmtCheckAll` fails if files need reformatting in any configuration (`Compile` and `Test` by default)

--- a/plugin/src/main/scala/com/lightbend/sbt/JavaFormatterPlugin.scala
+++ b/plugin/src/main/scala/com/lightbend/sbt/JavaFormatterPlugin.scala
@@ -20,7 +20,7 @@ import com.lightbend.sbt.javaformatter.JavaFormatter
 import sbt.Keys._
 import sbt.{ Def, _ }
 
-@deprecated("Use javafmtOnCompile setting instead", "0.5.0")
+@deprecated("Use javafmtOnCompile setting instead", "0.5.1")
 object AutomateJavaFormatterPlugin extends AutoPlugin {
   override def trigger = allRequirements
 

--- a/plugin/src/main/scala/com/lightbend/sbt/JavaFormatterPlugin.scala
+++ b/plugin/src/main/scala/com/lightbend/sbt/JavaFormatterPlugin.scala
@@ -20,14 +20,13 @@ import com.lightbend.sbt.javaformatter.JavaFormatter
 import sbt.Keys._
 import sbt.{ Def, _ }
 
+@deprecated("Use javafmtOnCompile setting instead", "0.5.0")
 object AutomateJavaFormatterPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
-  override def `requires` = plugins.JvmPlugin
+  override def `requires` = plugins.JvmPlugin && JavaFormatterPlugin
 
-  override def projectSettings =
-    Seq(Compile, Test).flatMap(inConfig(_)(compile := compile.dependsOn(JavaFormatterPlugin.autoImport.javafmt).value))
-
+  override def globalSettings: Seq[Def.Setting[_]] = Seq(JavaFormatterPlugin.autoImport.javafmtOnCompile := true)
 }
 
 object JavaFormatterPlugin extends AutoPlugin {
@@ -41,6 +40,7 @@ object JavaFormatterPlugin extends AutoPlugin {
     val javafmtCheckAll: TaskKey[Unit] = taskKey(
       "Execute the javafmtCheck task for all configurations in which it is enabled. " +
       "(By default this means the Compile and Test configurations.)")
+    val javafmtOnCompile = settingKey[Boolean]("Format Java source files on compile, on by default.")
   }
 
   import autoImport._
@@ -59,25 +59,41 @@ object JavaFormatterPlugin extends AutoPlugin {
       javafmtCheckAll := javafmtCheck.?.all(anyConfigsInThisProject).value)
   }
 
+  override def globalSettings: Seq[Def.Setting[_]] = Seq(javafmtOnCompile := false)
+
   def toBeScopedSettings: Seq[Setting[_]] =
-    List((javafmt / sourceDirectories) := List(javaSource.value), javafmt := {
-      val streamz = streams.value
-      val sD = (javafmt / sourceDirectories).value.toList
-      val iF = (javafmt / includeFilter).value
-      val eF = (javafmt / excludeFilter).value
-      val cache = streamz.cacheStoreFactory
-      JavaFormatter(sD, iF, eF, streamz, cache)
-    }, javafmtCheck := {
-      val streamz = streams.value
-      val baseDir = (ThisBuild / baseDirectory).value
-      val sD = (javafmt / sourceDirectories).value.toList
-      val iF = (javafmt / includeFilter).value
-      val eF = (javafmt / excludeFilter).value
-      val cache = (javafmt / streams).value.cacheStoreFactory
-      JavaFormatter.check(baseDir, sD, iF, eF, streamz, cache)
-    })
+    List(
+      (javafmt / sourceDirectories) := List(javaSource.value),
+      javafmt := {
+        val streamz = streams.value
+        val sD = (javafmt / sourceDirectories).value.toList
+        val iF = (javafmt / includeFilter).value
+        val eF = (javafmt / excludeFilter).value
+        val cache = streamz.cacheStoreFactory
+        JavaFormatter(sD, iF, eF, streamz, cache)
+      },
+      javafmtCheck := {
+        val streamz = streams.value
+        val baseDir = (ThisBuild / baseDirectory).value
+        val sD = (javafmt / sourceDirectories).value.toList
+        val iF = (javafmt / includeFilter).value
+        val eF = (javafmt / excludeFilter).value
+        val cache = (javafmt / streams).value.cacheStoreFactory
+        JavaFormatter.check(baseDir, sD, iF, eF, streamz, cache)
+      },
+      javafmtDoFormatOnCompile := Def.settingDyn {
+          if (javafmtOnCompile.value) {
+            javafmt in resolvedScoped.value.scope
+          } else {
+            Def.task(())
+          }
+        }.value,
+      compile / compileInputs := (compile / compileInputs).dependsOn(javafmtDoFormatOnCompile).value)
 
   def notToBeScopedSettings: Seq[Setting[_]] =
     List(includeFilter in javafmt := "*.java")
+
+  private[this] val javafmtDoFormatOnCompile =
+    taskKey[Unit]("Format Java source files if javafmtOnCompile is on.")
 
 }

--- a/plugin/src/sbt-test/sbt-java-formatter/on-compile/build.sbt
+++ b/plugin/src/sbt-test/sbt-java-formatter/on-compile/build.sbt
@@ -1,0 +1,3 @@
+// no settings needed
+
+ThisBuild / javafmtOnCompile := false

--- a/plugin/src/sbt-test/sbt-java-formatter/on-compile/project/build.properties
+++ b/plugin/src/sbt-test/sbt-java-formatter/on-compile/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.0

--- a/plugin/src/sbt-test/sbt-java-formatter/on-compile/project/plugins.sbt
+++ b/plugin/src/sbt-test/sbt-java-formatter/on-compile/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.lightbend.sbt"  % "sbt-java-formatter" % System.getProperty("plugin.version"))

--- a/plugin/src/sbt-test/sbt-java-formatter/on-compile/src/main/java-expected/com/lightbend/BadFormatting.java
+++ b/plugin/src/sbt-test/sbt-java-formatter/on-compile/src/main/java-expected/com/lightbend/BadFormatting.java
@@ -1,0 +1,6 @@
+package com.lightbend;
+
+public     class BadFormatting {
+  BadFormatting    () {example();}
+  public    void example     () {}
+}

--- a/plugin/src/sbt-test/sbt-java-formatter/on-compile/src/main/java/com/lightbend/BadFormatting.java
+++ b/plugin/src/sbt-test/sbt-java-formatter/on-compile/src/main/java/com/lightbend/BadFormatting.java
@@ -1,0 +1,6 @@
+package com.lightbend;
+
+public     class BadFormatting {
+  BadFormatting    () {example();}
+  public    void example     () {}
+}

--- a/plugin/src/sbt-test/sbt-java-formatter/on-compile/test
+++ b/plugin/src/sbt-test/sbt-java-formatter/on-compile/test
@@ -1,5 +1,5 @@
 # compile should trigger formatting
-> test:compile
+> compile
 
 #$ exec echo "====== FORMATTED ======"
 #$ exec cat src/main/java/com/lightbend/BadFormatting.java


### PR DESCRIPTION
Users could disable `AutomateJavaFormatterPlugin` however  i think it's not very intuitive; lmtk what do you think about adding this setting.

With this setting we have some parity with `scalafmtOnCompile`