### PR TITLE
Revert "Add JDK11 to travis"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 sudo: false
 language: scala
-
-matrix:
-  include:
-    - jdk: openjdk8
-    - jdk: openjdk11
+jdk: openjdk8
 
 jobs:
   include:


### PR DESCRIPTION
Reverts sbt/sbt-java-formatter#72

The release automation broke by this use of Travis build matrix and stages.