### PR TITLE
fix warning in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-lazy val sbtJavaFormatter = project.in(file(".")).aggregate(plugin).settings(skip in publish := true)
+lazy val sbtJavaFormatter = project.in(file(".")).aggregate(plugin).settings(publish / skip := true)
 
 lazy val plugin = project
   .in(file("plugin"))


### PR DESCRIPTION
```
sbt-java-formatter/build.sbt:1: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
lazy val sbtJavaFormatter = project.in(file(".")).aggregate(plugin).settings(skip in publish := true)
                                                                                  ^
```