### PR TITLE
Upgrade google formatter to v1.24.0 - the last version supporting Java 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            java: 8
+            java: 11
             distribution: zulu
             jobtype: 1
           - os: ubuntu-latest
-            java: 8
+            java: 11
             distribution: zulu
             jobtype: 2
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ jobs:
     - name: Setup Scala
       uses: olafurpg/setup-scala@v13
       with:
-        java-version: "adopt@1.8"
+        java-version: "adopt@11"
     - name: Setup JDK
       uses: actions/setup-java@v4
       with:
         distribution: temurin
-        java-version: 8
+        java-version: 11
         cache: sbt
     - uses: sbt/setup-sbt@v1
     - name: Release

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,9 +1,9 @@
 // really slow dependency updates, please
 pullRequests.frequency = "90 days"
 
-updates.ignore = [
-  // Releases after 1.7 require JDK 11
-  // https://github.com/google/google-java-format/releases/tag/google-java-format-1.8
-  { groupId = "com.google.googlejavaformat", artifactId = "google-java-format" }
+updates.pin = [
+  // Releases after 1.24.x require JDK 17
+  // https://github.com/google/google-java-format/releases/tag/v1.25.0
+  { groupId = "com.google.googlejavaformat", artifactId = "google-java-format", version = "1.24." }
 ]
 commits.message = "bump: ${artifactName} ${nextVersion} (was ${currentVersion})"

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ lazy val plugin = project
       ScmInfo(url("https://github.com/sbt/sbt-java-formatter"), "scm:git:git@github.com:sbt/sbt-java-formatter.git")),
     developers := List(
       Developer("ktoso", "Konrad 'ktoso' Malawski", "<ktoso@project13.pl>", url("https://github.com/ktoso"))),
-    libraryDependencies ++= Seq("com.google.googlejavaformat" % "google-java-format" % "1.7"),
+    libraryDependencies ++= Seq("com.google.googlejavaformat" % "google-java-format" % "1.24.0"),
     startYear := Some(2015),
     description := "Formats Java code in your project.",
     licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html")),

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-lazy val scala212 = "2.12.15"
+lazy val scala212 = "2.12.18"
 lazy val scala3 = "3.6.4"
 ThisBuild / scalaVersion := scala212
 ThisBuild / crossScalaVersions := Seq(scala212, scala3)

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ lazy val plugin = project
     licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html")),
     (pluginCrossBuild / sbtVersion) := {
       scalaBinaryVersion.value match {
-        case "2.12" => "1.5.8"
+        case "2.12" => "1.9.0"
         case _      => "2.0.0-M4"
       }
     },


### PR DESCRIPTION
First cut a release with this dependency, so people still requiring Java 11 can use it (cough cough Play 3.0.x ;)
After that upgrade to latest google java formatter that only supports Java 17:
https://github.com/google/google-java-format/releases/tag/v1.25.0