### PR TITLE
`--add-exports` instead of `--add-opens` as stated in the google-java-formatter docs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,8 +39,8 @@ lazy val plugin = project
     },
     scriptedLaunchOpts ++= {
       if (scala.util.Properties.isJavaAtLeast("17")) {
-        Seq("api", "file", "parser", "tree", "util").map { x =>
-          s"--add-opens=jdk.compiler/com.sun.tools.javac.${x}=ALL-UNNAMED"
+        Seq("api", "code", "file", "parser", "tree", "util").map { x =>
+          s"--add-exports=jdk.compiler/com.sun.tools.javac.${x}=ALL-UNNAMED"
         }
       } else {
         Nil


### PR DESCRIPTION
@xuwei-k why did you use `--add-opens` in  b62657ff ?
 
https://github.com/google/google-java-format/blob/master/README.md just talks about `--add-exports`.

Also I see `code` is not needed for the tests, but docs recommend it, so I added it for sake of completenesss.

Maybe I do not understand - can you clarifiy? or just approve this PR if you are OK with it. thanks!