### PR TITLE
feat: allow skipping sort-imports or remove-unused-imports

### DIFF
--- a/plugin/src/main/scala/com/github/sbt/JavaFormatterPlugin.scala
+++ b/plugin/src/main/scala/com/github/sbt/JavaFormatterPlugin.scala
@@ -19,7 +19,7 @@ package com.github.sbt
 import _root_.sbt.Keys._
 import _root_.sbt.{ Def, _ }
 import com.google.googlejavaformat.java.JavaFormatterOptions
-import com.github.sbt.javaformatter.JavaFormatter
+import com.github.sbt.javaformatter.{ JavaFormatter, OtherOptions }
 
 @deprecated("Use javafmtOnCompile setting instead", "0.5.1")
 object AutomateJavaFormatterPlugin extends AutoPlugin {
@@ -50,6 +50,8 @@ object JavaFormatterPlugin extends AutoPlugin {
       settingKey[JavaFormatterOptions.Style]("Define formatting style, Google Java Style (default) or AOSP")
     val javafmtOptions = settingKey[JavaFormatterOptions](
       "Define all formatting options such as style or enabling Javadoc formatting. See _JavaFormatterOptions_ for more")
+    val javafmtSortImports = settingKey[Boolean]("Whether to sort imports. Default: yes.")
+    val javafmtRemoveUnusedImports = settingKey[Boolean]("Whether to remove unused imports. Default: yes.")
   }
 
   import autoImport._
@@ -73,7 +75,11 @@ object JavaFormatterPlugin extends AutoPlugin {
   }
 
   override def globalSettings: Seq[Def.Setting[?]] =
-    Seq(javafmtOnCompile := false, javafmtStyle := JavaFormatterOptions.Style.GOOGLE)
+    Seq(
+      javafmtOnCompile := false,
+      javafmtStyle := JavaFormatterOptions.Style.GOOGLE,
+      javafmtSortImports := true,
+      javafmtRemoveUnusedImports := true)
 
   def toBeScopedSettings: Seq[Setting[?]] =
     List(
@@ -86,7 +92,8 @@ object JavaFormatterPlugin extends AutoPlugin {
         val eF = (javafmt / excludeFilter).value
         val cache = streamz.cacheStoreFactory
         val options = javafmtOptions.value
-        JavaFormatter(sD, iF, eF, streamz, cache, options)
+        val otherOptions = OtherOptions(javafmtSortImports.value, javafmtRemoveUnusedImports.value, javafmtStyle.value)
+        JavaFormatter(sD, iF, eF, streamz, cache, options, otherOptions)
       },
       javafmtCheck := {
         val streamz = streams.value
@@ -96,7 +103,8 @@ object JavaFormatterPlugin extends AutoPlugin {
         val eF = (javafmt / excludeFilter).value
         val cache = (javafmt / streams).value.cacheStoreFactory
         val options = javafmtOptions.value
-        JavaFormatter.check(baseDir, sD, iF, eF, streamz, cache, options)
+        val otherOptions = OtherOptions(javafmtSortImports.value, javafmtRemoveUnusedImports.value, javafmtStyle.value)
+        JavaFormatter.check(baseDir, sD, iF, eF, streamz, cache, options, otherOptions)
       },
       javafmtDoFormatOnCompile := Def.settingDyn {
         if (javafmtOnCompile.value) {

--- a/plugin/src/main/scala/com/github/sbt/javaformatter/JavaFormatter.scala
+++ b/plugin/src/main/scala/com/github/sbt/javaformatter/JavaFormatter.scala
@@ -20,8 +20,15 @@ import _root_.sbt.Keys._
 import _root_.sbt._
 import _root_.sbt.util.CacheImplicits._
 import _root_.sbt.util.{ CacheStoreFactory, FileInfo, Logger }
-import com.google.googlejavaformat.java.{ Formatter, JavaFormatterOptions }
+import com.google.googlejavaformat.java.{ Formatter, ImportOrderer, JavaFormatterOptions, RemoveUnusedImports }
+import com.google.googlejavaformat.java.JavaFormatterOptions.Style
 import scala.collection.immutable.Seq
+
+/**
+ * Other options, that upstream are passed around as CommandLineOptions, but that type is package-private so not usable
+ * as-is
+ */
+case class OtherOptions(sortImports: Boolean, removeUnusedImports: Boolean, style: Style)
 
 object JavaFormatter {
 
@@ -31,9 +38,10 @@ object JavaFormatter {
       excludeFilter: FileFilter,
       streams: TaskStreams,
       cacheStoreFactory: CacheStoreFactory,
-      options: JavaFormatterOptions): Unit = {
+      options: JavaFormatterOptions,
+      otherOptions: OtherOptions): Unit = {
     val files = sourceDirectories.descendantsExcept(includeFilter, excludeFilter).get().toList
-    cachedFormatSources(cacheStoreFactory, files, streams.log)(using new Formatter(options))
+    cachedFormatSources(cacheStoreFactory, files, streams.log)(using new Formatter(options), otherOptions)
   }
 
   def check(
@@ -43,9 +51,11 @@ object JavaFormatter {
       excludeFilter: FileFilter,
       streams: TaskStreams,
       cacheStoreFactory: CacheStoreFactory,
-      options: JavaFormatterOptions): Boolean = {
+      options: JavaFormatterOptions,
+      otherOptions: OtherOptions): Boolean = {
     val files = sourceDirectories.descendantsExcept(includeFilter, excludeFilter).get().toList
-    val analysis = cachedCheckSources(cacheStoreFactory, baseDir, files, streams.log)(using new Formatter(options))
+    val analysis =
+      cachedCheckSources(cacheStoreFactory, baseDir, files, streams.log)(using new Formatter(options), otherOptions)
     trueOrBoom(analysis)
   }
 
@@ -73,7 +83,9 @@ object JavaFormatter {
   }
 
   private def cachedCheckSources(cacheStoreFactory: CacheStoreFactory, baseDir: File, sources: Seq[File], log: Logger)(
-      implicit formatter: Formatter): Analysis = {
+      implicit
+      formatter: Formatter,
+      otherOptions: OtherOptions): Analysis = {
     trackSourcesViaCache(cacheStoreFactory, sources) { (outDiff, prev) =>
       log.debug(outDiff.toString)
       val updatedOrAdded = outDiff.modified & outDiff.checked
@@ -89,7 +101,9 @@ object JavaFormatter {
     log.warn(s"${file.toString} isn't formatted properly!")
   }
 
-  private def checkSources(baseDir: File, sources: Seq[File], log: Logger)(implicit formatter: Formatter): Analysis = {
+  private def checkSources(baseDir: File, sources: Seq[File], log: Logger)(implicit
+      formatter: Formatter,
+      otherOptions: OtherOptions): Analysis = {
     if (sources.nonEmpty) {
       log.info(s"Checking ${sources.size} Java source${plural(sources.size)}...")
     }
@@ -104,7 +118,8 @@ object JavaFormatter {
   }
 
   private def cachedFormatSources(cacheStoreFactory: CacheStoreFactory, sources: Seq[File], log: Logger)(implicit
-      formatter: Formatter): Unit = {
+      formatter: Formatter,
+      otherOptions: OtherOptions): Unit = {
     trackSourcesViaCache(cacheStoreFactory, sources) { (outDiff, prev) =>
       log.debug(outDiff.toString)
       val updatedOrAdded = outDiff.modified & outDiff.checked
@@ -117,7 +132,9 @@ object JavaFormatter {
     }
   }
 
-  private def formatSources(sources: Set[File], log: Logger)(implicit formatter: Formatter): Unit = {
+  private def formatSources(sources: Set[File], log: Logger)(implicit
+      formatter: Formatter,
+      otherOptions: OtherOptions): Unit = {
     val cnt = withFormattedSources(sources.toList, log)((file, input, output) => {
       if (input != output) {
         IO.write(file, output)
@@ -141,12 +158,27 @@ object JavaFormatter {
     prevTracker(())
   }
 
+  private def fixImports(input: String)(implicit parameters: OtherOptions): String = {
+    if (parameters.removeUnusedImports) {
+      if (parameters.sortImports) {
+        return ImportOrderer.reorderImports(RemoveUnusedImports.removeUnusedImports(input), parameters.style)
+      } else {
+        return RemoveUnusedImports.removeUnusedImports(input);
+      }
+    } else if (parameters.sortImports) {
+      return ImportOrderer.reorderImports(input, parameters.style);
+    } else {
+      return input;
+    }
+  }
+
   private def withFormattedSources[T](sources: Seq[File], log: Logger)(onFormat: (File, String, String) => T)(implicit
-      formatter: Formatter): Seq[Option[T]] = {
+      formatter: Formatter,
+      otherOptions: OtherOptions): Seq[Option[T]] = {
     sources.map { file =>
       val input = IO.read(file)
       try {
-        val output = formatter.formatSourceAndFixImports(input)
+        val output = fixImports(formatter.formatSource(input))
         Some(onFormat(file, input, output))
       } catch {
         case e: Exception => Some(onFormat(file, input, input))


### PR DESCRIPTION
Similar to upstreams' `CommandLineOptions`

Fixes #251

Draft because untested