### PR TITLE
Add settings for import handling and long string reflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ For available versions see [releases](https://github.com/sbt/sbt-java-formatter/
 
 * The `javafmtOnCompile` setting controls whether the formatter kicks in on compile (`false` by default).
 * The `javafmtStyle` setting defines the formatting style: Google Java Style (by default) or AOSP style.
+* The `javafmtSortImports` setting controls whether imports are sorted (`true` by default).
+* The `javafmtRemoveUnusedImports` setting controls whether unused imports are removed (`true` by default).
+* The `javafmtReflowLongStrings` setting controls whether long string literals are reflowed (`true` by default).
 * The `javafmtJavaMaxHeap` setting controls the maximum heap passed to the forked `google-java-format` JVM (`Some("256m")` by default).
 
 This plugin requires sbt 1.3.0+.
@@ -60,6 +63,18 @@ Set it to `None` to disable the explicit heap cap:
 ```scala
 ThisBuild / javafmtJavaMaxHeap := None
 ```
+
+## Formatter Options
+
+The plugin also exposes a few `google-java-format` CLI options directly:
+
+```scala
+ThisBuild / javafmtSortImports := true
+ThisBuild / javafmtRemoveUnusedImports := true
+ThisBuild / javafmtReflowLongStrings := true
+```
+
+Set any of them to `false` to pass the corresponding `--skip-...` flag to `google-java-format`.
 
 If you want to tweak the format, take a minute to consider whether it is really worth it, and have a look at the motivations in the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
 If you decide you really need more flexibility, you could consider other plugins such as the [sbt-checkstyle-plugin](https://github.com/etsy/sbt-checkstyle-plugin)

--- a/plugin/src/main/scala/com/github/sbt/JavaFormatterPlugin.scala
+++ b/plugin/src/main/scala/com/github/sbt/JavaFormatterPlugin.scala
@@ -50,6 +50,12 @@ object JavaFormatterPlugin extends AutoPlugin {
       settingKey[JavaFormatterOptions.Style]("Define formatting style, Google Java Style (default) or AOSP")
     val javafmtJavaMaxHeap =
       settingKey[Option[String]]("Maximum heap size passed to the forked google-java-format JVM, e.g. Some(\"256m\").")
+    val javafmtSortImports =
+      settingKey[Boolean]("Whether google-java-format should sort imports. Enabled by default.")
+    val javafmtRemoveUnusedImports =
+      settingKey[Boolean]("Whether google-java-format should remove unused imports. Enabled by default.")
+    val javafmtReflowLongStrings =
+      settingKey[Boolean]("Whether google-java-format should reflow long string literals. Enabled by default.")
     val javafmtOptions = settingKey[JavaFormatterOptions](
       "Define all formatting options such as style or enabling Javadoc formatting. See _JavaFormatterOptions_ for more")
   }
@@ -78,7 +84,10 @@ object JavaFormatterPlugin extends AutoPlugin {
     Seq(
       javafmtOnCompile := false,
       javafmtStyle := JavaFormatterOptions.Style.GOOGLE,
-      javafmtJavaMaxHeap := Some("256m"))
+      javafmtJavaMaxHeap := Some("256m"),
+      javafmtSortImports := true,
+      javafmtRemoveUnusedImports := true,
+      javafmtReflowLongStrings := true)
 
   def toBeScopedSettings: Seq[Setting[?]] =
     List(
@@ -92,7 +101,20 @@ object JavaFormatterPlugin extends AutoPlugin {
         val cache = streamz.cacheStoreFactory
         val options = javafmtOptions.value
         val javaMaxHeap = javafmtJavaMaxHeap.value
-        JavaFormatter(sD, iF, eF, streamz, cache, options, javaMaxHeap)
+        val sortImports = javafmtSortImports.value
+        val removeUnusedImports = javafmtRemoveUnusedImports.value
+        val reflowLongStrings = javafmtReflowLongStrings.value
+        JavaFormatter(
+          sD,
+          iF,
+          eF,
+          streamz,
+          cache,
+          options,
+          javaMaxHeap,
+          sortImports,
+          removeUnusedImports,
+          reflowLongStrings)
       },
       javafmtCheck := {
         val streamz = streams.value
@@ -103,7 +125,21 @@ object JavaFormatterPlugin extends AutoPlugin {
         val cache = (javafmt / streams).value.cacheStoreFactory
         val options = javafmtOptions.value
         val javaMaxHeap = javafmtJavaMaxHeap.value
-        JavaFormatter.check(baseDir, sD, iF, eF, streamz, cache, options, javaMaxHeap)
+        val sortImports = javafmtSortImports.value
+        val removeUnusedImports = javafmtRemoveUnusedImports.value
+        val reflowLongStrings = javafmtReflowLongStrings.value
+        JavaFormatter.check(
+          baseDir,
+          sD,
+          iF,
+          eF,
+          streamz,
+          cache,
+          options,
+          javaMaxHeap,
+          sortImports,
+          removeUnusedImports,
+          reflowLongStrings)
       },
       javafmtDoFormatOnCompile := Def.settingDyn {
         if (javafmtOnCompile.value) {

--- a/plugin/src/main/scala/com/github/sbt/javaformatter/JavaFormatter.scala
+++ b/plugin/src/main/scala/com/github/sbt/javaformatter/JavaFormatter.scala
@@ -42,9 +42,20 @@ object JavaFormatter {
       streams: TaskStreams,
       cacheStoreFactory: CacheStoreFactory,
       options: JavaFormatterOptions,
-      javaMaxHeap: Option[String]): Unit = {
+      javaMaxHeap: Option[String],
+      sortImports: Boolean,
+      removeUnusedImports: Boolean,
+      reflowLongStrings: Boolean): Unit = {
     val files = sourceDirectories.descendantsExcept(includeFilter, excludeFilter).get().toList
-    cachedFormatSources(cacheStoreFactory, files, streams.log, options, javaMaxHeap)
+    cachedFormatSources(
+      cacheStoreFactory,
+      files,
+      streams.log,
+      options,
+      javaMaxHeap,
+      sortImports,
+      removeUnusedImports,
+      reflowLongStrings)
   }
 
   def check(
@@ -55,9 +66,22 @@ object JavaFormatter {
       streams: TaskStreams,
       cacheStoreFactory: CacheStoreFactory,
       options: JavaFormatterOptions,
-      javaMaxHeap: Option[String]): Boolean = {
+      javaMaxHeap: Option[String],
+      sortImports: Boolean,
+      removeUnusedImports: Boolean,
+      reflowLongStrings: Boolean): Boolean = {
     val files = sourceDirectories.descendantsExcept(includeFilter, excludeFilter).get().toList
-    val analysis = cachedCheckSources(cacheStoreFactory, baseDir, files, streams.log, options, javaMaxHeap)
+    val analysis =
+      cachedCheckSources(
+        cacheStoreFactory,
+        baseDir,
+        files,
+        streams.log,
+        options,
+        javaMaxHeap,
+        sortImports,
+        removeUnusedImports,
+        reflowLongStrings)
     trueOrBoom(analysis)
   }
 
@@ -90,14 +114,25 @@ object JavaFormatter {
       sources: Seq[File],
       log: Logger,
       options: JavaFormatterOptions,
-      javaMaxHeap: Option[String]): Analysis = {
+      javaMaxHeap: Option[String],
+      sortImports: Boolean,
+      removeUnusedImports: Boolean,
+      reflowLongStrings: Boolean): Analysis = {
     trackSourcesViaCache(cacheStoreFactory, sources) { (outDiff, prev) =>
       log.debug(outDiff.toString)
       val updatedOrAdded = outDiff.modified & outDiff.checked
       val filesToCheck: Set[File] = updatedOrAdded
       val prevFailed: Set[File] = prev.failedCheck & outDiff.unmodified
       prevFailed.foreach { file => warnBadFormat(file.relativeTo(baseDir).getOrElse(file), log) }
-      val result = checkSources(baseDir, filesToCheck.toList, log, options, javaMaxHeap)
+      val result = checkSources(
+        baseDir,
+        filesToCheck.toList,
+        log,
+        options,
+        javaMaxHeap,
+        sortImports,
+        removeUnusedImports,
+        reflowLongStrings)
       prev.copy(failedCheck = result.failedCheck | prevFailed)
     }
   }
@@ -111,11 +146,15 @@ object JavaFormatter {
       sources: Seq[File],
       log: Logger,
       options: JavaFormatterOptions,
-      javaMaxHeap: Option[String]): Analysis = {
+      javaMaxHeap: Option[String],
+      sortImports: Boolean,
+      removeUnusedImports: Boolean,
+      reflowLongStrings: Boolean): Analysis = {
     if (sources.nonEmpty) {
       log.info(s"Checking ${sources.size} Java source${plural(sources.size)}...")
     }
-    val unformatted = runCheck(baseDir, sources, log, options, javaMaxHeap)
+    val unformatted =
+      runCheck(baseDir, sources, log, options, javaMaxHeap, sortImports, removeUnusedImports, reflowLongStrings)
     unformatted.foreach { file => warnBadFormat(file.relativeTo(baseDir).getOrElse(file), log) }
     Analysis(failedCheck = unformatted)
   }
@@ -125,14 +164,17 @@ object JavaFormatter {
       sources: Seq[File],
       log: Logger,
       options: JavaFormatterOptions,
-      javaMaxHeap: Option[String]): Unit = {
+      javaMaxHeap: Option[String],
+      sortImports: Boolean,
+      removeUnusedImports: Boolean,
+      reflowLongStrings: Boolean): Unit = {
     trackSourcesViaCache(cacheStoreFactory, sources) { (outDiff, prev) =>
       log.debug(outDiff.toString)
       val updatedOrAdded = outDiff.modified & outDiff.checked
       val filesToFormat: Set[File] = updatedOrAdded | prev.failedCheck
       if (filesToFormat.nonEmpty) {
         log.info(s"Formatting ${filesToFormat.size} Java source${plural(filesToFormat.size)}...")
-        formatSources(filesToFormat, log, options, javaMaxHeap)
+        formatSources(filesToFormat, log, options, javaMaxHeap, sortImports, removeUnusedImports, reflowLongStrings)
       }
       Analysis(Set.empty)
     }
@@ -142,11 +184,23 @@ object JavaFormatter {
       sources: Set[File],
       log: Logger,
       options: JavaFormatterOptions,
-      javaMaxHeap: Option[String]): Unit = {
+      javaMaxHeap: Option[String],
+      sortImports: Boolean,
+      removeUnusedImports: Boolean,
+      reflowLongStrings: Boolean): Unit = {
     val changed =
-      runCheck(baseDir = new File("."), sources.toList, log, options, javaMaxHeap, warnOnFailure = false)
+      runCheck(
+        baseDir = new File("."),
+        sources.toList,
+        log,
+        options,
+        javaMaxHeap,
+        sortImports,
+        removeUnusedImports,
+        reflowLongStrings,
+        warnOnFailure = false)
     if (changed.nonEmpty) {
-      runReplace(changed.toList, log, options, javaMaxHeap)
+      runReplace(changed.toList, log, options, javaMaxHeap, sortImports, removeUnusedImports, reflowLongStrings)
     }
     val cnt = changed.size
     log.info(s"Reformatted $cnt Java source${plural(cnt)}")
@@ -164,19 +218,30 @@ object JavaFormatter {
     prevTracker(())
   }
 
-  private def cliFlags(options: JavaFormatterOptions): Seq[String] = {
-    if (!options.reorderModifiers()) {
-      throw new MessageOnlyException(
-        "The forked google-java-format CLI does not support reorderModifiers = false. " +
-        "Please use the default reorderModifiers setting.")
-    }
+  private def cliFlags(
+      options: JavaFormatterOptions,
+      sortImports: Boolean,
+      removeUnusedImports: Boolean,
+      reflowLongStrings: Boolean): Seq[String] = {
     val styleFlags =
       if (options.style() == JavaFormatterOptions.Style.AOSP) Seq("--aosp")
       else Nil
     val javadocFlags =
       if (options.formatJavadoc()) Nil
       else Seq("--skip-javadoc-formatting")
-    styleFlags ++ javadocFlags
+    val reorderModifiersFlags =
+      if (options.reorderModifiers()) Nil
+      else Seq("--skip-reordering-modifiers")
+    val sortImportsFlags =
+      if (sortImports) Nil
+      else Seq("--skip-sorting-imports")
+    val removeUnusedImportsFlags =
+      if (removeUnusedImports) Nil
+      else Seq("--skip-removing-unused-imports")
+    val reflowLongStringsFlags =
+      if (reflowLongStrings) Nil
+      else Seq("--skip-reflowing-long-strings")
+    styleFlags ++ javadocFlags ++ reorderModifiersFlags ++ sortImportsFlags ++ removeUnusedImportsFlags ++ reflowLongStringsFlags
   }
 
   private case class CliResult(exitCode: Int, stdout: Vector[String], stderr: Vector[String])
@@ -233,11 +298,17 @@ object JavaFormatter {
       log: Logger,
       options: JavaFormatterOptions,
       javaMaxHeap: Option[String],
+      sortImports: Boolean,
+      removeUnusedImports: Boolean,
+      reflowLongStrings: Boolean,
       warnOnFailure: Boolean = true): Set[File] = {
     if (sources.isEmpty) {
       return Set.empty
     }
-    val args = cliFlags(options) ++ Seq("--dry-run", "--set-exit-if-changed") ++ sources.map(_.getAbsolutePath)
+    val args =
+      cliFlags(options, sortImports, removeUnusedImports, reflowLongStrings) ++ Seq(
+        "--dry-run",
+        "--set-exit-if-changed") ++ sources.map(_.getAbsolutePath)
     val result = runCli(args, log, javaMaxHeap)
     val changed = result.stdout.iterator.map(path => file(path)).toSet
     result.exitCode match {
@@ -256,11 +327,16 @@ object JavaFormatter {
       sources: Seq[File],
       log: Logger,
       options: JavaFormatterOptions,
-      javaMaxHeap: Option[String]): Unit = {
+      javaMaxHeap: Option[String],
+      sortImports: Boolean,
+      removeUnusedImports: Boolean,
+      reflowLongStrings: Boolean): Unit = {
     if (sources.isEmpty) {
       return
     }
-    val args = cliFlags(options) ++ Seq("--replace") ++ sources.map(_.getAbsolutePath)
+    val args =
+      cliFlags(options, sortImports, removeUnusedImports, reflowLongStrings) ++ Seq("--replace") ++ sources.map(
+        _.getAbsolutePath)
     val result = runCli(args, log, javaMaxHeap)
     if (result.exitCode != 0) {
       result.stderr.foreach(line => log.error(line))

--- a/plugin/src/sbt-test/sbt-java-formatter/skip-reflowing-long-strings/build.sbt
+++ b/plugin/src/sbt-test/sbt-java-formatter/skip-reflowing-long-strings/build.sbt
@@ -1,0 +1,1 @@
+ThisBuild / javafmtReflowLongStrings := false

--- a/plugin/src/sbt-test/sbt-java-formatter/skip-reflowing-long-strings/project/plugins.sbt
+++ b/plugin/src/sbt-test/sbt-java-formatter/skip-reflowing-long-strings/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % System.getProperty("plugin.version"))

--- a/plugin/src/sbt-test/sbt-java-formatter/skip-reflowing-long-strings/src/main/java-expected/com/lightbend/BadFormatting.java
+++ b/plugin/src/sbt-test/sbt-java-formatter/skip-reflowing-long-strings/src/main/java-expected/com/lightbend/BadFormatting.java
@@ -1,0 +1,6 @@
+package com.lightbend;
+
+public class BadFormatting {
+  private final String value =
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+}

--- a/plugin/src/sbt-test/sbt-java-formatter/skip-reflowing-long-strings/src/main/java/com/lightbend/BadFormatting.java
+++ b/plugin/src/sbt-test/sbt-java-formatter/skip-reflowing-long-strings/src/main/java/com/lightbend/BadFormatting.java
@@ -1,0 +1,6 @@
+package com.lightbend;
+
+public class BadFormatting {
+  private final String value =
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+}

--- a/plugin/src/sbt-test/sbt-java-formatter/skip-reflowing-long-strings/test
+++ b/plugin/src/sbt-test/sbt-java-formatter/skip-reflowing-long-strings/test
@@ -1,0 +1,4 @@
+> javafmtCheck
+> javafmt
+
+$ exec diff src/main/java/com/lightbend/BadFormatting.java src/main/java-expected/com/lightbend/BadFormatting.java

--- a/plugin/src/sbt-test/sbt-java-formatter/skip-removing-unused-imports/build.sbt
+++ b/plugin/src/sbt-test/sbt-java-formatter/skip-removing-unused-imports/build.sbt
@@ -1,0 +1,1 @@
+ThisBuild / javafmtRemoveUnusedImports := false

--- a/plugin/src/sbt-test/sbt-java-formatter/skip-removing-unused-imports/project/plugins.sbt
+++ b/plugin/src/sbt-test/sbt-java-formatter/skip-removing-unused-imports/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % System.getProperty("plugin.version"))

--- a/plugin/src/sbt-test/sbt-java-formatter/skip-removing-unused-imports/src/main/java-expected/com/lightbend/BadFormatting.java
+++ b/plugin/src/sbt-test/sbt-java-formatter/skip-removing-unused-imports/src/main/java-expected/com/lightbend/BadFormatting.java
@@ -1,0 +1,8 @@
+package com.lightbend;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BadFormatting {
+  private final ArrayList<String> xs = new ArrayList<>();
+}

--- a/plugin/src/sbt-test/sbt-java-formatter/skip-removing-unused-imports/src/main/java/com/lightbend/BadFormatting.java
+++ b/plugin/src/sbt-test/sbt-java-formatter/skip-removing-unused-imports/src/main/java/com/lightbend/BadFormatting.java
@@ -1,0 +1,8 @@
+package com.lightbend;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BadFormatting {
+  private final ArrayList<String> xs = new ArrayList<>();
+}

--- a/plugin/src/sbt-test/sbt-java-formatter/skip-removing-unused-imports/test
+++ b/plugin/src/sbt-test/sbt-java-formatter/skip-removing-unused-imports/test
@@ -1,0 +1,4 @@
+> javafmtCheck
+> javafmt
+
+$ exec diff src/main/java/com/lightbend/BadFormatting.java src/main/java-expected/com/lightbend/BadFormatting.java

--- a/plugin/src/sbt-test/sbt-java-formatter/skip-sorting-imports/build.sbt
+++ b/plugin/src/sbt-test/sbt-java-formatter/skip-sorting-imports/build.sbt
@@ -1,0 +1,1 @@
+ThisBuild / javafmtSortImports := false

--- a/plugin/src/sbt-test/sbt-java-formatter/skip-sorting-imports/project/plugins.sbt
+++ b/plugin/src/sbt-test/sbt-java-formatter/skip-sorting-imports/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % System.getProperty("plugin.version"))

--- a/plugin/src/sbt-test/sbt-java-formatter/skip-sorting-imports/src/main/java-expected/com/lightbend/BadFormatting.java
+++ b/plugin/src/sbt-test/sbt-java-formatter/skip-sorting-imports/src/main/java-expected/com/lightbend/BadFormatting.java
@@ -1,0 +1,8 @@
+package com.lightbend;
+
+import java.util.List;
+import java.util.ArrayList;
+
+public class BadFormatting {
+  private final List<String> xs = new ArrayList<>();
+}

--- a/plugin/src/sbt-test/sbt-java-formatter/skip-sorting-imports/src/main/java/com/lightbend/BadFormatting.java
+++ b/plugin/src/sbt-test/sbt-java-formatter/skip-sorting-imports/src/main/java/com/lightbend/BadFormatting.java
@@ -1,0 +1,8 @@
+package com.lightbend;
+
+import java.util.List;
+import java.util.ArrayList;
+
+public class BadFormatting {
+  private final List<String> xs = new ArrayList<>();
+}

--- a/plugin/src/sbt-test/sbt-java-formatter/skip-sorting-imports/test
+++ b/plugin/src/sbt-test/sbt-java-formatter/skip-sorting-imports/test
@@ -1,0 +1,4 @@
+> javafmtCheck
+> javafmt
+
+$ exec diff src/main/java/com/lightbend/BadFormatting.java src/main/java-expected/com/lightbend/BadFormatting.java


### PR DESCRIPTION
This adds first-class sbt settings for a few `google-java-format` CLI options that are not part of `JavaFormatterOptions`, but are still supported by the formatter when invoked through the CLI.

Added settings:
- `javafmtSortImports`
- `javafmtRemoveUnusedImports`
- `javafmtReflowLongStrings`

These are wired through to the forked `google-java-format` process as:
- `--skip-sorting-imports`
- `--skip-removing-unused-imports`
- `--skip-reflowing-long-strings`

Documentation:
- README now documents the new settings and shows basic configuration examples

Add scripted coverage for each new setting, tested locally (also made them fail).

This keeps `javafmtOptions` for the upstream `JavaFormatterOptions` subset, while exposing the additional CLI-only options as dedicated sbt settings.