### PR TITLE
Add `javafmtFixImports` tasks for import-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ For available versions see [releases](https://github.com/sbt/sbt-java-formatter/
 * `javafmtAll` formats Java files for all configurations (`Compile` and `Test` by default)
 * `javafmtCheck` fails if files need reformatting
 * `javafmtCheckAll` fails if files need reformatting in any configuration (`Compile` and `Test` by default)
+* `javafmtFixImports` fixes Java imports only, without applying full formatting
+* `javafmtFixImportsAll` fixes Java imports only for all configurations (`Compile` and `Test` by default)
+* `javafmtFixImportsCheck` fails if Java imports need fixing
+* `javafmtFixImportsCheckAll` fails if Java imports need fixing in any configuration (`Compile` and `Test` by default)
 
 * The `javafmtOnCompile` setting controls whether the formatter kicks in on compile (`false` by default).
 * The `javafmtStyle` setting defines the formatting style: Google Java Style (by default) or AOSP style.

--- a/plugin/src/main/scala/com/github/sbt/JavaFormatterPlugin.scala
+++ b/plugin/src/main/scala/com/github/sbt/JavaFormatterPlugin.scala
@@ -38,12 +38,24 @@ object JavaFormatterPlugin extends AutoPlugin {
     @transient
     val javafmtCheck: TaskKey[Boolean] = taskKey("Fail, if a Java source needs reformatting.")
     @transient
+    val javafmtFixImports: TaskKey[Unit] = taskKey("Fix Java imports only, without applying full formatting.")
+    @transient
+    val javafmtFixImportsCheck: TaskKey[Boolean] = taskKey("Fail, if Java imports need fixing.")
+    @transient
     val javafmtAll: TaskKey[Unit] = taskKey(
       "Execute the javafmt task for all configurations in which it is enabled. " +
       "(By default this means the Compile and Test configurations.)")
     @transient
     val javafmtCheckAll: TaskKey[Unit] = taskKey(
       "Execute the javafmtCheck task for all configurations in which it is enabled. " +
+      "(By default this means the Compile and Test configurations.)")
+    @transient
+    val javafmtFixImportsAll: TaskKey[Unit] = taskKey(
+      "Execute the javafmtFixImports task for all configurations in which it is enabled. " +
+      "(By default this means the Compile and Test configurations.)")
+    @transient
+    val javafmtFixImportsCheckAll: TaskKey[Unit] = taskKey(
+      "Execute the javafmtFixImportsCheck task for all configurations in which it is enabled. " +
       "(By default this means the Compile and Test configurations.)")
     val javafmtOnCompile = settingKey[Boolean]("Format Java source files on compile, off by default.")
     val javafmtStyle =
@@ -77,6 +89,12 @@ object JavaFormatterPlugin extends AutoPlugin {
       },
       javafmtCheckAll := {
         val _ = javafmtCheck.?.all(anyConfigsInThisProject).value
+      },
+      javafmtFixImportsAll := {
+        val _ = javafmtFixImports.?.all(anyConfigsInThisProject).value
+      },
+      javafmtFixImportsCheckAll := {
+        val _ = javafmtFixImportsCheck.?.all(anyConfigsInThisProject).value
       })
   }
 
@@ -129,6 +147,54 @@ object JavaFormatterPlugin extends AutoPlugin {
         val removeUnusedImports = javafmtRemoveUnusedImports.value
         val reflowLongStrings = javafmtReflowLongStrings.value
         JavaFormatter.check(
+          baseDir,
+          sD,
+          iF,
+          eF,
+          streamz,
+          cache,
+          options,
+          javaMaxHeap,
+          sortImports,
+          removeUnusedImports,
+          reflowLongStrings)
+      },
+      javafmtFixImports := {
+        val streamz = streams.value
+        val sD = (javafmt / sourceDirectories).value.toList
+        val iF = (javafmt / includeFilter).value
+        val eF = (javafmt / excludeFilter).value
+        val cache = streamz.cacheStoreFactory
+        val options = javafmtOptions.value
+        val javaMaxHeap = javafmtJavaMaxHeap.value
+        val sortImports = javafmtSortImports.value
+        val removeUnusedImports = javafmtRemoveUnusedImports.value
+        val reflowLongStrings = javafmtReflowLongStrings.value
+        JavaFormatter.fixImports(
+          sD,
+          iF,
+          eF,
+          streamz,
+          cache,
+          options,
+          javaMaxHeap,
+          sortImports,
+          removeUnusedImports,
+          reflowLongStrings)
+      },
+      javafmtFixImportsCheck := {
+        val streamz = streams.value
+        val baseDir = (ThisBuild / baseDirectory).value
+        val sD = (javafmt / sourceDirectories).value.toList
+        val iF = (javafmt / includeFilter).value
+        val eF = (javafmt / excludeFilter).value
+        val cache = (javafmt / streams).value.cacheStoreFactory
+        val options = javafmtOptions.value
+        val javaMaxHeap = javafmtJavaMaxHeap.value
+        val sortImports = javafmtSortImports.value
+        val removeUnusedImports = javafmtRemoveUnusedImports.value
+        val reflowLongStrings = javafmtReflowLongStrings.value
+        JavaFormatter.fixImportsCheck(
           baseDir,
           sD,
           iF,

--- a/plugin/src/main/scala/com/github/sbt/javaformatter/JavaFormatter.scala
+++ b/plugin/src/main/scala/com/github/sbt/javaformatter/JavaFormatter.scala
@@ -53,6 +53,31 @@ object JavaFormatter {
       streams.log,
       options,
       javaMaxHeap,
+      fixImportsOnly = false,
+      sortImports,
+      removeUnusedImports,
+      reflowLongStrings)
+  }
+
+  def fixImports(
+      sourceDirectories: Seq[File],
+      includeFilter: FileFilter,
+      excludeFilter: FileFilter,
+      streams: TaskStreams,
+      cacheStoreFactory: CacheStoreFactory,
+      options: JavaFormatterOptions,
+      javaMaxHeap: Option[String],
+      sortImports: Boolean,
+      removeUnusedImports: Boolean,
+      reflowLongStrings: Boolean): Unit = {
+    val files = sourceDirectories.descendantsExcept(includeFilter, excludeFilter).get().toList
+    cachedFormatSources(
+      cacheStoreFactory,
+      files,
+      streams.log,
+      options,
+      javaMaxHeap,
+      fixImportsOnly = true,
       sortImports,
       removeUnusedImports,
       reflowLongStrings)
@@ -79,6 +104,35 @@ object JavaFormatter {
         streams.log,
         options,
         javaMaxHeap,
+        fixImportsOnly = false,
+        sortImports,
+        removeUnusedImports,
+        reflowLongStrings)
+    trueOrBoom(analysis)
+  }
+
+  def fixImportsCheck(
+      baseDir: File,
+      sourceDirectories: Seq[File],
+      includeFilter: FileFilter,
+      excludeFilter: FileFilter,
+      streams: TaskStreams,
+      cacheStoreFactory: CacheStoreFactory,
+      options: JavaFormatterOptions,
+      javaMaxHeap: Option[String],
+      sortImports: Boolean,
+      removeUnusedImports: Boolean,
+      reflowLongStrings: Boolean): Boolean = {
+    val files = sourceDirectories.descendantsExcept(includeFilter, excludeFilter).get().toList
+    val analysis =
+      cachedCheckSources(
+        cacheStoreFactory,
+        baseDir,
+        files,
+        streams.log,
+        options,
+        javaMaxHeap,
+        fixImportsOnly = true,
         sortImports,
         removeUnusedImports,
         reflowLongStrings)
@@ -115,6 +169,7 @@ object JavaFormatter {
       log: Logger,
       options: JavaFormatterOptions,
       javaMaxHeap: Option[String],
+      fixImportsOnly: Boolean,
       sortImports: Boolean,
       removeUnusedImports: Boolean,
       reflowLongStrings: Boolean): Analysis = {
@@ -130,6 +185,7 @@ object JavaFormatter {
         log,
         options,
         javaMaxHeap,
+        fixImportsOnly,
         sortImports,
         removeUnusedImports,
         reflowLongStrings)
@@ -147,6 +203,7 @@ object JavaFormatter {
       log: Logger,
       options: JavaFormatterOptions,
       javaMaxHeap: Option[String],
+      fixImportsOnly: Boolean,
       sortImports: Boolean,
       removeUnusedImports: Boolean,
       reflowLongStrings: Boolean): Analysis = {
@@ -154,7 +211,16 @@ object JavaFormatter {
       log.info(s"Checking ${sources.size} Java source${plural(sources.size)}...")
     }
     val unformatted =
-      runCheck(baseDir, sources, log, options, javaMaxHeap, sortImports, removeUnusedImports, reflowLongStrings)
+      runCheck(
+        baseDir,
+        sources,
+        log,
+        options,
+        javaMaxHeap,
+        fixImportsOnly,
+        sortImports,
+        removeUnusedImports,
+        reflowLongStrings)
     unformatted.foreach { file => warnBadFormat(file.relativeTo(baseDir).getOrElse(file), log) }
     Analysis(failedCheck = unformatted)
   }
@@ -165,6 +231,7 @@ object JavaFormatter {
       log: Logger,
       options: JavaFormatterOptions,
       javaMaxHeap: Option[String],
+      fixImportsOnly: Boolean,
       sortImports: Boolean,
       removeUnusedImports: Boolean,
       reflowLongStrings: Boolean): Unit = {
@@ -174,7 +241,15 @@ object JavaFormatter {
       val filesToFormat: Set[File] = updatedOrAdded | prev.failedCheck
       if (filesToFormat.nonEmpty) {
         log.info(s"Formatting ${filesToFormat.size} Java source${plural(filesToFormat.size)}...")
-        formatSources(filesToFormat, log, options, javaMaxHeap, sortImports, removeUnusedImports, reflowLongStrings)
+        formatSources(
+          filesToFormat,
+          log,
+          options,
+          javaMaxHeap,
+          fixImportsOnly,
+          sortImports,
+          removeUnusedImports,
+          reflowLongStrings)
       }
       Analysis(Set.empty)
     }
@@ -185,6 +260,7 @@ object JavaFormatter {
       log: Logger,
       options: JavaFormatterOptions,
       javaMaxHeap: Option[String],
+      fixImportsOnly: Boolean,
       sortImports: Boolean,
       removeUnusedImports: Boolean,
       reflowLongStrings: Boolean): Unit = {
@@ -195,12 +271,21 @@ object JavaFormatter {
         log,
         options,
         javaMaxHeap,
+        fixImportsOnly,
         sortImports,
         removeUnusedImports,
         reflowLongStrings,
         warnOnFailure = false)
     if (changed.nonEmpty) {
-      runReplace(changed.toList, log, options, javaMaxHeap, sortImports, removeUnusedImports, reflowLongStrings)
+      runReplace(
+        changed.toList,
+        log,
+        options,
+        javaMaxHeap,
+        fixImportsOnly,
+        sortImports,
+        removeUnusedImports,
+        reflowLongStrings)
     }
     val cnt = changed.size
     log.info(s"Reformatted $cnt Java source${plural(cnt)}")
@@ -220,6 +305,7 @@ object JavaFormatter {
 
   private def cliFlags(
       options: JavaFormatterOptions,
+      fixImportsOnly: Boolean,
       sortImports: Boolean,
       removeUnusedImports: Boolean,
       reflowLongStrings: Boolean): Seq[String] = {
@@ -232,6 +318,9 @@ object JavaFormatter {
     val reorderModifiersFlags =
       if (options.reorderModifiers()) Nil
       else Seq("--skip-reordering-modifiers")
+    val fixImportsOnlyFlags =
+      if (fixImportsOnly) Seq("--fix-imports-only")
+      else Nil
     val sortImportsFlags =
       if (sortImports) Nil
       else Seq("--skip-sorting-imports")
@@ -241,7 +330,7 @@ object JavaFormatter {
     val reflowLongStringsFlags =
       if (reflowLongStrings) Nil
       else Seq("--skip-reflowing-long-strings")
-    styleFlags ++ javadocFlags ++ reorderModifiersFlags ++ sortImportsFlags ++ removeUnusedImportsFlags ++ reflowLongStringsFlags
+    styleFlags ++ javadocFlags ++ reorderModifiersFlags ++ fixImportsOnlyFlags ++ sortImportsFlags ++ removeUnusedImportsFlags ++ reflowLongStringsFlags
   }
 
   private case class CliResult(exitCode: Int, stdout: Vector[String], stderr: Vector[String])
@@ -298,6 +387,7 @@ object JavaFormatter {
       log: Logger,
       options: JavaFormatterOptions,
       javaMaxHeap: Option[String],
+      fixImportsOnly: Boolean,
       sortImports: Boolean,
       removeUnusedImports: Boolean,
       reflowLongStrings: Boolean,
@@ -306,7 +396,7 @@ object JavaFormatter {
       return Set.empty
     }
     val args =
-      cliFlags(options, sortImports, removeUnusedImports, reflowLongStrings) ++ Seq(
+      cliFlags(options, fixImportsOnly, sortImports, removeUnusedImports, reflowLongStrings) ++ Seq(
         "--dry-run",
         "--set-exit-if-changed") ++ sources.map(_.getAbsolutePath)
     val result = runCli(args, log, javaMaxHeap)
@@ -328,6 +418,7 @@ object JavaFormatter {
       log: Logger,
       options: JavaFormatterOptions,
       javaMaxHeap: Option[String],
+      fixImportsOnly: Boolean,
       sortImports: Boolean,
       removeUnusedImports: Boolean,
       reflowLongStrings: Boolean): Unit = {
@@ -335,8 +426,8 @@ object JavaFormatter {
       return
     }
     val args =
-      cliFlags(options, sortImports, removeUnusedImports, reflowLongStrings) ++ Seq("--replace") ++ sources.map(
-        _.getAbsolutePath)
+      cliFlags(options, fixImportsOnly, sortImports, removeUnusedImports, reflowLongStrings) ++ Seq(
+        "--replace") ++ sources.map(_.getAbsolutePath)
     val result = runCli(args, log, javaMaxHeap)
     if (result.exitCode != 0) {
       result.stderr.foreach(line => log.error(line))

--- a/plugin/src/sbt-test/sbt-java-formatter/fix-imports-only-check/build.sbt
+++ b/plugin/src/sbt-test/sbt-java-formatter/fix-imports-only-check/build.sbt
@@ -1,0 +1,1 @@
+// no settings needed

--- a/plugin/src/sbt-test/sbt-java-formatter/fix-imports-only-check/project/plugins.sbt
+++ b/plugin/src/sbt-test/sbt-java-formatter/fix-imports-only-check/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % System.getProperty("plugin.version"))

--- a/plugin/src/sbt-test/sbt-java-formatter/fix-imports-only-check/src/main/java-expected/com/lightbend/BadFormatting.java
+++ b/plugin/src/sbt-test/sbt-java-formatter/fix-imports-only-check/src/main/java-expected/com/lightbend/BadFormatting.java
@@ -1,0 +1,8 @@
+package com.lightbend;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public     class BadFormatting {
+  BadFormatting    () {List<String> xs = new ArrayList<>();}
+}

--- a/plugin/src/sbt-test/sbt-java-formatter/fix-imports-only-check/src/main/java/com/lightbend/BadFormatting.java
+++ b/plugin/src/sbt-test/sbt-java-formatter/fix-imports-only-check/src/main/java/com/lightbend/BadFormatting.java
@@ -1,0 +1,9 @@
+package com.lightbend;
+
+import java.util.List;
+import java.util.Collections;
+import java.util.ArrayList;
+
+public     class BadFormatting {
+  BadFormatting    () {List<String> xs = new ArrayList<>();}
+}

--- a/plugin/src/sbt-test/sbt-java-formatter/fix-imports-only-check/test
+++ b/plugin/src/sbt-test/sbt-java-formatter/fix-imports-only-check/test
@@ -1,0 +1,5 @@
+-> javafmtFixImportsCheck
+> javafmtFixImports
+> javafmtFixImportsCheck
+
+$ exec diff src/main/java/com/lightbend/BadFormatting.java src/main/java-expected/com/lightbend/BadFormatting.java

--- a/plugin/src/sbt-test/sbt-java-formatter/fix-imports-only/build.sbt
+++ b/plugin/src/sbt-test/sbt-java-formatter/fix-imports-only/build.sbt
@@ -1,0 +1,1 @@
+// no settings needed

--- a/plugin/src/sbt-test/sbt-java-formatter/fix-imports-only/project/plugins.sbt
+++ b/plugin/src/sbt-test/sbt-java-formatter/fix-imports-only/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % System.getProperty("plugin.version"))

--- a/plugin/src/sbt-test/sbt-java-formatter/fix-imports-only/src/main/java-expected/com/lightbend/BadFormatting.java
+++ b/plugin/src/sbt-test/sbt-java-formatter/fix-imports-only/src/main/java-expected/com/lightbend/BadFormatting.java
@@ -1,0 +1,8 @@
+package com.lightbend;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public     class BadFormatting {
+  BadFormatting    () {List<String> xs = new ArrayList<>();}
+}

--- a/plugin/src/sbt-test/sbt-java-formatter/fix-imports-only/src/main/java/com/lightbend/BadFormatting.java
+++ b/plugin/src/sbt-test/sbt-java-formatter/fix-imports-only/src/main/java/com/lightbend/BadFormatting.java
@@ -1,0 +1,9 @@
+package com.lightbend;
+
+import java.util.List;
+import java.util.Collections;
+import java.util.ArrayList;
+
+public     class BadFormatting {
+  BadFormatting    () {List<String> xs = new ArrayList<>();}
+}

--- a/plugin/src/sbt-test/sbt-java-formatter/fix-imports-only/test
+++ b/plugin/src/sbt-test/sbt-java-formatter/fix-imports-only/test
@@ -1,0 +1,3 @@
+> javafmtFixImports
+
+$ exec diff src/main/java/com/lightbend/BadFormatting.java src/main/java-expected/com/lightbend/BadFormatting.java


### PR DESCRIPTION
Adds dedicated import-only tasks backed by google-java-format's `--fix-imports-only` CLI mode.

New tasks:
- `javafmtFixImports`
- `javafmtFixImportsCheck`
- `javafmtFixImportsAll`
- `javafmtFixImportsCheckAll`

Why tasks instead of a setting?

`--fix-imports-only` is not just another formatting preference. It changes the meaning of the run from "format this file" to "only touch imports and leave the rest of the file alone". Because of that, modeling it as a persistent setting would be surprising:
enabling it would silently change what `javafmt` and `javafmtCheck` do.

Dedicated tasks make that behavior explicit:
- `javafmt` and `javafmtCheck` remain full formatting tasks
- `javafmtFixImports` and `javafmtFixImportsCheck` are clearly import-only operations

This also fits better with how people use it in practice. Import-only cleanup is usually something you invoke intentionally for a specific workflow, not a mode you want to keep enabled all the time.

Behavior details:
- `javafmtFixImports...` does not format the rest of the Java file
- it only runs the import-fixing step from google-java-format
- only `javafmtRemoveUnusedImports` and `javafmtSortImports` influence these tasks
- other formatting-related settings do not matter in this mode, because full formatting is skipped

This PR also adds scripted coverage for the new import-only tasks and documents them in the README.
