### PR TITLE
Add `javafmtFormatJavadoc` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ For available versions see [releases](https://github.com/sbt/sbt-java-formatter/
 * The `javafmtSortImports` setting controls whether imports are sorted (`true` by default).
 * The `javafmtRemoveUnusedImports` setting controls whether unused imports are removed (`true` by default).
 * The `javafmtReflowLongStrings` setting controls whether long string literals are reflowed (`true` by default).
+* The `javafmtFormatJavadoc` setting controls whether Javadoc comments are reformatted (`true` by default).
 * The `javafmtJavaMaxHeap` setting controls the maximum heap passed to the forked `google-java-format` JVM (`Some("256m")` by default).
 
 This plugin requires sbt 1.3.0+.
@@ -76,9 +77,16 @@ The plugin also exposes a few `google-java-format` CLI options directly:
 ThisBuild / javafmtSortImports := true
 ThisBuild / javafmtRemoveUnusedImports := true
 ThisBuild / javafmtReflowLongStrings := true
+ThisBuild / javafmtFormatJavadoc := true
 ```
 
 Set any of them to `false` to pass the corresponding `--skip-...` flag to `google-java-format`.
+
+`javafmtOptions` is still available for compatibility, but the preferred sbt-facing configuration is through the dedicated `javafmt...` settings above.
+
+`JavaFormatterOptions.reorderModifiers()` currently has no effect in this plugin.
+
+The plugin now runs `google-java-format` via its CLI in a forked JVM, and the released `google-java-format` CLI used here [does not yet support a corresponding `--skip-reordering-modifiers` flag](https://github.com/google/google-java-format/pull/1373).
 
 If you want to tweak the format, take a minute to consider whether it is really worth it, and have a look at the motivations in the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
 If you decide you really need more flexibility, you could consider other plugins such as the [sbt-checkstyle-plugin](https://github.com/etsy/sbt-checkstyle-plugin)

--- a/plugin/src/main/scala/com/github/sbt/JavaFormatterPlugin.scala
+++ b/plugin/src/main/scala/com/github/sbt/JavaFormatterPlugin.scala
@@ -68,8 +68,10 @@ object JavaFormatterPlugin extends AutoPlugin {
       settingKey[Boolean]("Whether google-java-format should remove unused imports. Enabled by default.")
     val javafmtReflowLongStrings =
       settingKey[Boolean]("Whether google-java-format should reflow long string literals. Enabled by default.")
+    val javafmtFormatJavadoc =
+      settingKey[Boolean]("Whether google-java-format should format Javadoc comments. Enabled by default.")
     val javafmtOptions = settingKey[JavaFormatterOptions](
-      "Define all formatting options such as style or enabling Javadoc formatting. See _JavaFormatterOptions_ for more")
+      "Compatibility setting for upstream JavaFormatterOptions. Prefer the dedicated javafmt... settings; reorderModifiers() currently has no effect with the released google-java-format CLI used by this plugin.")
   }
 
   import autoImport._
@@ -105,12 +107,17 @@ object JavaFormatterPlugin extends AutoPlugin {
       javafmtJavaMaxHeap := Some("256m"),
       javafmtSortImports := true,
       javafmtRemoveUnusedImports := true,
-      javafmtReflowLongStrings := true)
+      javafmtReflowLongStrings := true,
+      javafmtFormatJavadoc := true)
 
   def toBeScopedSettings: Seq[Setting[?]] =
     List(
       (javafmt / sourceDirectories) := List(javaSource.value),
-      javafmtOptions := JavaFormatterOptions.builder().style(javafmtStyle.value).build(),
+      javafmtOptions := JavaFormatterOptions
+        .builder()
+        .style(javafmtStyle.value)
+        .formatJavadoc(javafmtFormatJavadoc.value)
+        .build(),
       javafmt := {
         val streamz = streams.value
         val sD = (javafmt / sourceDirectories).value.toList

--- a/plugin/src/sbt-test/sbt-java-formatter/skip-javadoc-formatting/build.sbt
+++ b/plugin/src/sbt-test/sbt-java-formatter/skip-javadoc-formatting/build.sbt
@@ -1,0 +1,1 @@
+ThisBuild / javafmtFormatJavadoc := false

--- a/plugin/src/sbt-test/sbt-java-formatter/skip-javadoc-formatting/project/plugins.sbt
+++ b/plugin/src/sbt-test/sbt-java-formatter/skip-javadoc-formatting/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % System.getProperty("plugin.version"))

--- a/plugin/src/sbt-test/sbt-java-formatter/skip-javadoc-formatting/src/main/java-expected/com/lightbend/BadFormatting.java
+++ b/plugin/src/sbt-test/sbt-java-formatter/skip-javadoc-formatting/src/main/java-expected/com/lightbend/BadFormatting.java
@@ -1,0 +1,9 @@
+package com.lightbend;
+
+/**
+ * hello
+ * world
+ */
+public class BadFormatting {
+  public void example() {}
+}

--- a/plugin/src/sbt-test/sbt-java-formatter/skip-javadoc-formatting/src/main/java/com/lightbend/BadFormatting.java
+++ b/plugin/src/sbt-test/sbt-java-formatter/skip-javadoc-formatting/src/main/java/com/lightbend/BadFormatting.java
@@ -1,0 +1,9 @@
+package com.lightbend;
+
+/**
+* hello
+* world
+*/
+public     class BadFormatting{
+  public    void example     () {}
+}

--- a/plugin/src/sbt-test/sbt-java-formatter/skip-javadoc-formatting/test
+++ b/plugin/src/sbt-test/sbt-java-formatter/skip-javadoc-formatting/test
@@ -1,0 +1,4 @@
+-> javafmtCheck
+> javafmt
+
+$ exec diff src/main/java/com/lightbend/BadFormatting.java src/main/java-expected/com/lightbend/BadFormatting.java


### PR DESCRIPTION
Adds a first-class sbt setting for controlling google-java-format's Javadoc formatting behavior:

- `javafmtFormatJavadoc`

This follows the same direction as the recent CLI-backed settings such as:

- `javafmtSortImports`
- `javafmtRemoveUnusedImports`
- `javafmtReflowLongStrings`

Instead of requiring users to go through `javafmtOptions`, the common sbt-facing configuration is now exposed directly as a dedicated setting:

```scala
ThisBuild / javafmtFormatJavadoc := false
```

Why this change?

Since the plugin now runs google-java-format in a forked JVM via its CLI, the natural public API is the set of CLI-backed formatter toggles exposed as normal sbt settings. That makes configuration more explicit and easier to discover in the `README`, and
reduces reliance on the upstream `JavaFormatterOptions` object as the primary user-facing API.

This PR also updates the README to clarify the current state of `javafmtOptions`:

- it is still available for compatibility
- the preferred configuration path is through the dedicated `javafmt...` settings
- `JavaFormatterOptions.reorderModifiers()` currently has no effect in this plugin, because the released google-java-format CLI used here does not yet support a corresponding `--skip-reordering-modifiers` flag. See:
  - #266
  - https://github.com/google/google-java-format/pull/1373

Finally, this adds a scripted test that verifies `javafmtFormatJavadoc := false` preserves Javadoc content formatting while still applying normal code formatting around it.
