### PR TITLE
Restore reorderModifiers guard for the forked formatter CLI

### DIFF
--- a/plugin/src/main/scala/com/github/sbt/javaformatter/JavaFormatter.scala
+++ b/plugin/src/main/scala/com/github/sbt/javaformatter/JavaFormatter.scala
@@ -309,15 +309,17 @@ object JavaFormatter {
       sortImports: Boolean,
       removeUnusedImports: Boolean,
       reflowLongStrings: Boolean): Seq[String] = {
+    if (!options.reorderModifiers()) {
+      throw new MessageOnlyException(
+        "The forked google-java-format CLI does not support reorderModifiers = false. " +
+        "Please use the default reorderModifiers setting.")
+    }
     val styleFlags =
       if (options.style() == JavaFormatterOptions.Style.AOSP) Seq("--aosp")
       else Nil
     val javadocFlags =
       if (options.formatJavadoc()) Nil
       else Seq("--skip-javadoc-formatting")
-    val reorderModifiersFlags =
-      if (options.reorderModifiers()) Nil
-      else Seq("--skip-reordering-modifiers")
     val fixImportsOnlyFlags =
       if (fixImportsOnly) Seq("--fix-imports-only")
       else Nil
@@ -330,7 +332,7 @@ object JavaFormatter {
     val reflowLongStringsFlags =
       if (reflowLongStrings) Nil
       else Seq("--skip-reflowing-long-strings")
-    styleFlags ++ javadocFlags ++ reorderModifiersFlags ++ fixImportsOnlyFlags ++ sortImportsFlags ++ removeUnusedImportsFlags ++ reflowLongStringsFlags
+    styleFlags ++ javadocFlags ++ fixImportsOnlyFlags ++ sortImportsFlags ++ removeUnusedImportsFlags ++ reflowLongStringsFlags
   }
 
   private case class CliResult(exitCode: Int, stdout: Vector[String], stderr: Vector[String])

--- a/plugin/src/sbt-test/sbt-java-formatter/reorder-modifiers-unsupported/build.sbt
+++ b/plugin/src/sbt-test/sbt-java-formatter/reorder-modifiers-unsupported/build.sbt
@@ -1,0 +1,8 @@
+import com.google.googlejavaformat.java.JavaFormatterOptions
+
+Compile / javafmtOptions := JavaFormatterOptions
+  .builder()
+  .style(javafmtStyle.value)
+  .formatJavadoc(javafmtFormatJavadoc.value)
+  .reorderModifiers(false)
+  .build()

--- a/plugin/src/sbt-test/sbt-java-formatter/reorder-modifiers-unsupported/project/plugins.sbt
+++ b/plugin/src/sbt-test/sbt-java-formatter/reorder-modifiers-unsupported/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % System.getProperty("plugin.version"))

--- a/plugin/src/sbt-test/sbt-java-formatter/reorder-modifiers-unsupported/src/main/java/com/lightbend/BadFormatting.java
+++ b/plugin/src/sbt-test/sbt-java-formatter/reorder-modifiers-unsupported/src/main/java/com/lightbend/BadFormatting.java
@@ -1,0 +1,6 @@
+package com.lightbend;
+
+public     class BadFormatting {
+  BadFormatting    () {example();}
+  public    void example     () {}
+}

--- a/plugin/src/sbt-test/sbt-java-formatter/reorder-modifiers-unsupported/test
+++ b/plugin/src/sbt-test/sbt-java-formatter/reorder-modifiers-unsupported/test
@@ -1,0 +1,2 @@
+-> javafmt
+-> javafmtCheck


### PR DESCRIPTION
Restores the fail-fast guard for `JavaFormatterOptions.reorderModifiers(false)`.

 The released `google-java-format` CLI used by this plugin does not yet support `--skip-reordering-modifiers`, so `reorderModifiers = false` is not currently a valid CLI-backed configuration.

 This fixes an accidental regression introduced in aae9cc9, which removed the guard and started passing an unsupported CLI flag.

Added a scripted test to nail things down.
