### PR TITLE
Support overriding the formatter Java home

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ This plugin uses the [Google Java Format](https://github.com/google/google-java-
 
 The formatter runs in a forked JVM managed by the plugin.
 
+By default it uses the same Java installation as the sbt process via `java.home`.
+
+To make the plugin launch the formatter with a different Java installation, set either:
+
+- the `sbt-javafmt.java.home` JVM system property
+- or the `SBT_JAVAFMT_JAVA_HOME` environment variable
+
+If both are set, `sbt-javafmt.java.home` takes precedence.
+
 Use `javafmtJavaMaxHeap` to control the maximum heap size passed to that JVM:
 
 ```scala

--- a/plugin/src/main/scala/com/github/sbt/javaformatter/JavaFormatter.scala
+++ b/plugin/src/main/scala/com/github/sbt/javaformatter/JavaFormatter.scala
@@ -30,6 +30,8 @@ import scala.sys.process.{ Process, ProcessLogger }
 object JavaFormatter {
 
   private val GoogleJavaFormatMain = "com.google.googlejavaformat.java.Main"
+  private val JavaHomeEnvVar = "SBT_JAVAFMT_JAVA_HOME"
+  private val JavaHomeProperty = "sbt-javafmt.java.home"
 
   private val JavaExports = Seq("api", "code", "file", "parser", "tree", "util").map { exportedPackage =>
     s"--add-exports=jdk.compiler/com.sun.tools.javac.$exportedPackage=ALL-UNNAMED"
@@ -351,14 +353,23 @@ object JavaFormatter {
     classpathFrom(getClass.getClassLoader).distinct.mkString(File.pathSeparator)
 
   private lazy val javaBin: String = {
-    val javaHome = new File(sys.props("java.home"))
+    val javaHomeSourceAndPath =
+      sys.props
+        .get(JavaHomeProperty)
+        .filter(_.nonEmpty)
+        .map(path => (JavaHomeProperty, path))
+        .orElse(sys.env.get(JavaHomeEnvVar).filter(_.nonEmpty).map(path => (JavaHomeEnvVar, path)))
+        .getOrElse(("java.home", sys.props("java.home")))
+    val (javaHomeSource, javaHomePath) = javaHomeSourceAndPath
+    val javaHome = new File(javaHomePath)
     val unixJava = new File(javaHome, "bin/java")
     val windowsJava = new File(javaHome, "bin/java.exe")
     val javaExec =
       if (unixJava.isFile) unixJava
       else if (windowsJava.isFile) windowsJava
       else {
-        throw new MessageOnlyException(s"Could not locate a Java launcher under java.home=${javaHome.getAbsolutePath}")
+        throw new MessageOnlyException(
+          s"Could not locate a Java launcher under ${javaHomeSource}=${javaHome.getAbsolutePath}")
       }
     javaExec.getAbsolutePath
   }


### PR DESCRIPTION
Adds explicit Java home overrides for the forked `google-java-format` JVM.

The plugin currently falls back to the same Java installation used by the sbt process via `java.home`. This works well by default, but on CI servers or developer machines it can be useful to run the formatter with a different JDK without changing the JDK that sbt itself runs on.

This change adds two override mechanisms:

1. JVM system property: `sbt-javafmt.java.home`
2. Environment variable: `SBT_JAVAFMT_JAVA_HOME`

Resolution order is now:

1. `sbt-javafmt.java.home`
2. `SBT_JAVAFMT_JAVA_HOME`
3. `java.home`

So users can now do either of these:

```bash
sbt -Dsbt-javafmt.java.home=/path/to/jdk javafmt

SBT_JAVAFMT_JAVA_HOME=/path/to/jdk sbt javafmt
```

The plugin still defaults to sbt's own `java.home` when neither override is set.

