### PR TITLE
Use a Scala Steward hook to update the runtime google-java-format mapping

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,9 +1,13 @@
 // really slow dependency updates, please
 pullRequests.frequency = "90 days"
 
-updates.pin = [
-  // Releases after 1.24.x require JDK 17
-  // https://github.com/google/google-java-format/releases/tag/v1.25.0
-  { groupId = "com.google.googlejavaformat", artifactId = "google-java-format", version = "1.24." }
-]
 commits.message = "bump: ${artifactName} ${nextVersion} (was ${currentVersion})"
+
+postUpdateHooks = [
+  {
+    groupId = "com.google.googlejavaformat"
+    artifactId = "google-java-format"
+    command = ["bash", "scripts/update-google-java-format-runtime.sh"]
+    commitMessage = "Update google-java-format runtime mapping"
+  }
+]

--- a/scripts/update-google-java-format-runtime.sh
+++ b/scripts/update-google-java-format-runtime.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+build_file="$repo_root/build.sbt"
+plugin_file="$repo_root/plugin/src/main/scala/com/github/sbt/JavaFormatterPlugin.scala"
+readme_file="$repo_root/README.md"
+
+compile_api_version="1.24.0"
+
+# Assumption:
+# the latest google-java-format release continues to belong to the Java 21
+# compatibility bucket. If upstream raises the runtime requirement again,
+# update this hook and the compatibility mapping policy.
+
+extract_version() {
+  sed -n 's/.*"com\.google\.googlejavaformat" % "google-java-format" % "\([^"]*\)".*/\1/p' "$build_file" | head -n1
+}
+
+detected_version="$(extract_version)"
+
+if [[ -z "$detected_version" ]]; then
+  echo "Could not determine google-java-format version from $build_file" >&2
+  exit 1
+fi
+
+if [[ "$detected_version" == "$compile_api_version" ]]; then
+  echo "google-java-format compile API version is unchanged at $compile_api_version; nothing to rewrite."
+  exit 0
+fi
+
+perl -0pi -e 's/"com\.google\.googlejavaformat" % "google-java-format" % "[^"]*"/"com.google.googlejavaformat" % "google-java-format" % "'"$compile_api_version"'"/' "$build_file"
+perl -0pi -e 's/case 21\s*=> "\Q'"$detected_version"'\E"|case 21\s*=> "[^"]*"/case 21    => "'"$detected_version"'"/' "$plugin_file"
+perl -0pi -e 's/- `21` -> `google-java-format [^`]*`/- `21` -> `google-java-format '"$detected_version"'`/' "$readme_file"
+
+echo "Updated runtime google-java-format version to $detected_version and restored build.sbt to $compile_api_version."


### PR DESCRIPTION
## Summary

This changes how Scala Steward should handle `google-java-format` updates in this repository.

We intentionally keep the compile-time dependency in `build.sbt` on `1.24.0`, because the plugin is compiled against the Java 11-compatible API line. However, the runtime formatter selection is tracked separately through:

- `formatterVersionForCompatibleJavaVersion` in `JavaFormatterPlugin.scala`
- the compatibility table in `README.md`

Scala Steward cannot express that policy directly by itself. If we just unpin the dependency, it would normally only update the version in `build.sbt`, which is not what we want.

## What this does

This PR removes the Scala Steward pin for `google-java-format` and adds a `postUpdateHook` for that dependency.

When Scala Steward bumps the version in `build.sbt`, the hook script now:

1. reads the bumped `google-java-format` version from `build.sbt`
2. restores the compile-time dependency in `build.sbt` back to `1.24.0`
3. updates the Java 21 runtime mapping in `JavaFormatterPlugin.scala`
4. updates the corresponding Java 21 entry in `README.md`

So Scala Steward still uses the normal dependency update mechanism as the trigger, but the final diff is redirected to the files that actually represent the runtime formatter policy.

## Why this is needed

The project currently has two different concerns:

- compile the plugin against a stable Java 11-compatible formatter API line
- let the forked formatter runtime track newer `google-java-format` releases for newer JDKs

Scala Steward understands dependency versions in build files, but not this repository-specific split between compile-time and runtime formatter versions. The hook makes that policy explicit.

## Note

The hook includes a comment documenting the current assumption behind this automation:

- the latest `google-java-format` release continues to belong to the Java 21 compatibility bucket

If upstream raises the runtime requirement again in the future, the hook and compatibility policy will need to be adjusted.
