### PR TITLE
Downgrade google-java-format to test scala steward hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Set any of them to `false` to pass the corresponding `--skip-...` flag to `googl
 
 - `11` -> `google-java-format 1.24.0`
 - `17` -> `google-java-format 1.28.0`
-- `21` -> `google-java-format 1.35.0`
+- `21` -> `google-java-format 1.34.0`
 
 If the selected formatter runtime is newer than the Java used to launch the formatter JVM, either:
 

--- a/plugin/src/main/scala/com/github/sbt/JavaFormatterPlugin.scala
+++ b/plugin/src/main/scala/com/github/sbt/JavaFormatterPlugin.scala
@@ -259,7 +259,7 @@ object JavaFormatterPlugin extends AutoPlugin {
     compatibleJavaVersion match {
       case 11    => "1.24.0"
       case 17    => "1.28.0"
-      case 21    => "1.35.0"
+      case 21    => "1.34.0"
       case other =>
         throw new MessageOnlyException(
           s"Unsupported javafmtFormatterCompatibleJavaVersion: $other. Expected one of: 11, 17, 21.")


### PR DESCRIPTION
When scala stewards runs next time those versions should be increased again.